### PR TITLE
Lu.infra.migration.n extends.types

### DIFF
--- a/NExtends.Tests/GenericsTests.cs
+++ b/NExtends.Tests/GenericsTests.cs
@@ -1,11 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+using NExtends.Primitives;
+using NExtends.Primitives.Types;
+using NExtends.Tests.Models;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NExtends.Tests.Models;
-using NExtends.Primitives;
 
 namespace NExtends.Tests
 {

--- a/NExtends.Tests/NExtends.Tests.csproj
+++ b/NExtends.Tests/NExtends.Tests.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Models\GenericTestsInterfaceI.cs" />
     <Compile Include="Models\GenericTestsClassU.cs" />
     <Compile Include="Models\GenericTestsClassT.cs" />
+    <Compile Include="Primitives\Types\Type.extensions.tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EnumExtensionsTests.cs" />
     <Compile Include="StringExtensionsTests.cs" />

--- a/NExtends.Tests/Primitives/Types/Type.extensions.tests.cs
+++ b/NExtends.Tests/Primitives/Types/Type.extensions.tests.cs
@@ -1,18 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NExtends.Primitives.Types;
 
 namespace NExtends.Tests.Primitives.Types
 {
+	[TestClass]
 	public class TypeExtensionsTest
 	{
-		//TODO : passer à xUnit et décommenter ce test
-		//[Fact]
-		//public void IsSubclassOfInterfaceShouldHandleNonGenericInterfaces()
-		//{
-		//	Assert.True(typeof(System.Collections.ArrayList).IsSubclassOfInterface(typeof(System.Collections.IEnumerable)));
-		//}
+		[TestMethod]
+		public void IsSubclassOfInterfaceShouldHandleNonGenericInterfaces()
+		{
+			Assert.IsTrue(typeof(System.Collections.ArrayList).IsSubclassOfInterface(typeof(System.Collections.IEnumerable)));
+		}
 	}
 }

--- a/NExtends.Tests/Primitives/Types/Type.extensions.tests.cs
+++ b/NExtends.Tests/Primitives/Types/Type.extensions.tests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NExtends.Tests.Primitives.Types
+{
+	public class TypeExtensionsTest
+	{
+		//TODO : passer à xUnit et décommenter ce test
+		//[Fact]
+		//public void IsSubclassOfInterfaceShouldHandleNonGenericInterfaces()
+		//{
+		//	Assert.True(typeof(System.Collections.ArrayList).IsSubclassOfInterface(typeof(System.Collections.IEnumerable)));
+		//}
+	}
+}

--- a/NExtends/NExtends.csproj
+++ b/NExtends/NExtends.csproj
@@ -80,7 +80,7 @@
     <Compile Include="Primitives\Object.extensions.cs" />
     <Compile Include="Primitives\String.extensions.cs" />
     <Compile Include="Primitives\TimeSpan.extensions.cs" />
-    <Compile Include="Primitives\Type.extensions.cs" />
+    <Compile Include="Primitives\Types\Type.extensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NExtends/Primitives/Types/Type.extensions.cs
+++ b/NExtends/Primitives/Types/Type.extensions.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using NExtends.Attributes;
 using System;
 using System.CodeDom;
 using System.CodeDom.Compiler;
@@ -6,12 +7,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
-using Newtonsoft.Json;
-using NExtends.Attributes;
 using System.Linq.Expressions;
+using System.Reflection;
 
-namespace NExtends.Primitives
+namespace NExtends.Primitives.Types
 {
 	public static class TypeExtensions
 	{


### PR DESCRIPTION
Move Types extensions in specific folder, in order to isolate each extensions from one to another.

**Breaking Change**

- each reference to NExtends.Primitives/Type.extensions.cs must be replaced with reference to NExtends.Primitives.Types