### PR TITLE
Generic.extensions

### DIFF
--- a/NExtends.Tests/GenericsTests.cs
+++ b/NExtends.Tests/GenericsTests.cs
@@ -69,14 +69,14 @@ namespace NExtends.Tests
             collection = null;
             Assert.Throws<ArgumentNullException>(() =>
             {
-                collection.AddMany("1"); 
+                collection.AddMany("1");
             });
             Assert.Throws<ArgumentNullException>(() =>
-            { 
-                collection.AddRange(new[] { "1" }); 
+            {
+                collection.AddRange(new[] { "1" });
             });
             Assert.Throws<ArgumentNullException>(() =>
-            { 
+            {
                 collection.RemoveRange(new[] { "1" });
             });
         }
@@ -84,7 +84,7 @@ namespace NExtends.Tests
         [Fact]
         public void IsNullOrEmptyTest()
         {
-            var full = new List<string> {""};
+            var full = new List<string> { "" };
             var empty = new List<string>();
             List<string> nulled = null;
 
@@ -105,6 +105,43 @@ namespace NExtends.Tests
                 hashset = full.ToHashSet();
             });
         }
+
+
+        [Fact]
+        public void ContainsTest()
+        {
+            var x = new[] { "1", "2" };
+            var y = new[] { "2", "1" };
+            Assert.True(x.Contains(y));
+            Assert.True(y.Contains(x));
+            y = null;
+            Assert.False(x.Contains(y));
+            Assert.False(y.Contains(x));
+            x = null;
+            Assert.True(x.Contains(y));
+            Assert.True(y.Contains(x));
+
+            x = new[] { "1", "2", "3" };
+            y = new[] { "2", "1" };
+            Assert.False(x.Contains(y));
+            Assert.False(y.Contains(x));
+
+            x = new[] { "1", "2", "1" };
+            y = new[] { "2", "1" };
+            Assert.False(x.Contains(y));
+            Assert.False(y.Contains(x));
+
+            x = new[] { "1", "2", "1" };
+            y = new[] { "2", "1", "2" };
+            Assert.False(x.Contains(y));
+            Assert.False(y.Contains(x));
+
+            x = new[] { "1", "2", "1", null };
+            y = new[] { "2", "1" , null, null};
+            Assert.False(x.Contains(y));
+            Assert.False(y.Contains(x));
+        }
+
 
         [Fact]
         public void CastingCollectionOfClassToAnotherThroughtInterfaceShouldWork()

--- a/NExtends.Tests/GenericsTests.cs
+++ b/NExtends.Tests/GenericsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NExtends.Tests.Models;
@@ -7,36 +8,59 @@ using Xunit;
 
 namespace NExtends.Tests
 {
-	public class GenericsTests
-	{
-		[Fact]
-		public void CastingCollectionOfClassToAnotherThroughtInterfaceShouldWork()
-		{
-			var t = new GenericTestsClassT() { Id = 1, Name = "T", CustomT = "CustomT", UnexpectedCommonName = "Common" };
+    public class GenericsTests
+    {
+        [Fact]
+        public void ToDictionaryTest()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                { "1","1"},
+                { "2","2"}
+            };
 
-			var collection = new HashSet<GenericTestsClassT>() { t };
+            Dictionary<string, string> newDictionary = dic.Where(i => i.Key == "1").ToDictionary();
 
-			var result = collection.Cast<GenericTestsClassT, GenericTestsClassU, GenericTestsInterfaceI>().SingleOrDefault();
+            Assert.True(newDictionary.ContainsKey("1"));
+            Assert.Single(newDictionary);
 
-			Assert.NotNull(result);
-			Assert.Equal(1, result.Id);
-			Assert.Equal("T", result.Name);
-			Assert.Null(result.CustomU);
-			Assert.Null(result.UnexpectedCommonName);
-		}
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                IEnumerable<KeyValuePair<string, string>> nulled = null;
+                nulled.ToDictionary();
+            });
+            Assert.Empty(Enumerable.Empty<KeyValuePair<string, string>>().ToDictionary());
+        }
 
-		[Fact]
-		public void CastingObjectOfClassToAnotherThroughtInterfaceShouldWork()
-		{
-			var t = new GenericTestsClassT() { Id = 1, Name = "T", CustomT = "CustomT", UnexpectedCommonName = "Common" };
 
-			var result = t.Cast<GenericTestsClassT, GenericTestsClassU, GenericTestsInterfaceI>();
+        [Fact]
+        public void CastingCollectionOfClassToAnotherThroughtInterfaceShouldWork()
+        {
+            var t = new GenericTestsClassT() { Id = 1, Name = "T", CustomT = "CustomT", UnexpectedCommonName = "Common" };
 
-			Assert.NotNull(result);
-			Assert.Equal(1, result.Id);
-			Assert.Equal("T", result.Name);
-			Assert.Null(result.CustomU);
-			Assert.Null(result.UnexpectedCommonName);
-		}
-	}
+            var collection = new HashSet<GenericTestsClassT>() { t };
+
+            var result = collection.Cast<GenericTestsClassT, GenericTestsClassU, GenericTestsInterfaceI>().SingleOrDefault();
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Id);
+            Assert.Equal("T", result.Name);
+            Assert.Null(result.CustomU);
+            Assert.Null(result.UnexpectedCommonName);
+        }
+
+        [Fact]
+        public void CastingObjectOfClassToAnotherThroughtInterfaceShouldWork()
+        {
+            var t = new GenericTestsClassT() { Id = 1, Name = "T", CustomT = "CustomT", UnexpectedCommonName = "Common" };
+
+            var result = t.Cast<GenericTestsClassT, GenericTestsClassU, GenericTestsInterfaceI>();
+
+            Assert.NotNull(result);
+            Assert.Equal(1, result.Id);
+            Assert.Equal("T", result.Name);
+            Assert.Null(result.CustomU);
+            Assert.Null(result.UnexpectedCommonName);
+        }
+    }
 }

--- a/NExtends.Tests/GenericsTests.cs
+++ b/NExtends.Tests/GenericsTests.cs
@@ -41,7 +41,7 @@ namespace NExtends.Tests
                 { "y","value_y"},
                 { "z","value_z"}
             };
-            dic.UpdateKey("x","xx");
+            dic.UpdateKey("x", "xx");
             Assert.Equal("value_x", dic["xx"]);
             Assert.Throws<ArgumentException>(() =>
             {
@@ -55,6 +55,29 @@ namespace NExtends.Tests
             {
                 Dictionary<string, string> nulled = null;
                 nulled.UpdateKey("aaa", "bbbb");
+            });
+        }
+
+        [Fact]
+        public void CollectionTests()
+        {
+            ICollection<string> collection = new List<string>();
+            collection.AddMany("1");
+            collection.AddRange(new[] { "2", "3", "4", "5" });
+            collection.RemoveRange(new[] { "4", "5" });
+            Assert.Equal(3, collection.Count);
+            collection = null;
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                collection.AddMany("1"); 
+            });
+            Assert.Throws<ArgumentNullException>(() =>
+            { 
+                collection.AddRange(new[] { "1" }); 
+            });
+            Assert.Throws<ArgumentNullException>(() =>
+            { 
+                collection.RemoveRange(new[] { "1" });
             });
         }
 

--- a/NExtends.Tests/GenericsTests.cs
+++ b/NExtends.Tests/GenericsTests.cs
@@ -32,6 +32,31 @@ namespace NExtends.Tests
             Assert.Empty(Enumerable.Empty<KeyValuePair<string, string>>().ToDictionary());
         }
 
+        [Fact]
+        public void UpdateKeyTest()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                { "x","value_x"},
+                { "y","value_y"},
+                { "z","value_z"}
+            };
+            dic.UpdateKey("x","xx");
+            Assert.Equal("value_x", dic["xx"]);
+            Assert.Throws<ArgumentException>(() =>
+            {
+                dic.UpdateKey("y", "z");
+            });
+            Assert.Throws<KeyNotFoundException>(() =>
+            {
+                dic.UpdateKey("aaa", "bbbb");
+            });
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                Dictionary<string, string> nulled = null;
+                nulled.UpdateKey("aaa", "bbbb");
+            });
+        }
 
         [Fact]
         public void CastingCollectionOfClassToAnotherThroughtInterfaceShouldWork()

--- a/NExtends.Tests/GenericsTests.cs
+++ b/NExtends.Tests/GenericsTests.cs
@@ -93,6 +93,18 @@ namespace NExtends.Tests
             Assert.False(full.IsNullOrEmpty());
         }
 
+        [Fact]
+        public void ToHashSetTest()
+        {
+            var full = new List<string> { "" };
+            var hashset = full.ToHashSet();
+            Assert.NotEmpty(hashset);
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                full = null;
+                hashset = full.ToHashSet();
+            });
+        }
 
         [Fact]
         public void CastingCollectionOfClassToAnotherThroughtInterfaceShouldWork()

--- a/NExtends.Tests/GenericsTests.cs
+++ b/NExtends.Tests/GenericsTests.cs
@@ -82,6 +82,19 @@ namespace NExtends.Tests
         }
 
         [Fact]
+        public void IsNullOrEmptyTest()
+        {
+            var full = new List<string> {""};
+            var empty = new List<string>();
+            List<string> nulled = null;
+
+            Assert.True(empty.IsNullOrEmpty());
+            Assert.True(nulled.IsNullOrEmpty());
+            Assert.False(full.IsNullOrEmpty());
+        }
+
+
+        [Fact]
         public void CastingCollectionOfClassToAnotherThroughtInterfaceShouldWork()
         {
             var t = new GenericTestsClassT() { Id = 1, Name = "T", CustomT = "CustomT", UnexpectedCommonName = "Common" };

--- a/NExtends/NExtends.csproj
+++ b/NExtends/NExtends.csproj
@@ -7,14 +7,6 @@
     <PackageVersion>2.0.0</PackageVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NET461</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />

--- a/NExtends/NExtends.csproj
+++ b/NExtends/NExtends.csproj
@@ -11,6 +11,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NET461</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace NExtends.Primitives
 {
@@ -184,9 +185,7 @@ namespace NExtends.Primitives
 			return new HashSet<T>(collection);
 		}
 
-		public static bool IsNullOrEmpty<T>(this IEnumerable<T> source)
-		{
-			return source == null || !source.Any();
-		}
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNullOrEmpty<T>(this IEnumerable<T> source) => source == null || !source.Any();
     }
 }

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -99,18 +99,6 @@ namespace NExtends.Primitives
 		}
         
 		/// <summary>
-		/// Permet d'ajouter une clé de type Enum sans devoir mettre un .ToString()
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="dic"></param>
-		/// <param name="enumValue"></param>
-		/// <returns></returns>
-		public static void Add<T>(this Dictionary<string, T> dic, Enum enumKey, T value)
-		{
-			dic.Add(enumKey.ToString(), value);
-		}
-
-		/// <summary>
 		/// Permet de renommer une clé
 		/// </summary>
 		/// <typeparam name="T"></typeparam>

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -97,18 +97,7 @@ namespace NExtends.Primitives
 		{
 			return list.Where(el => !String.IsNullOrEmpty(el)).Select(el => el.ToLower()).GroupBy(el => el.Split('.')[0]).ToDictionary(g => g.Key, g => g.All(s => s.Contains('.')) ? g.Select(s => String.Join(".", s.Split('.').Skip(1).ToArray())).ToList() : (List<string>)null, StringComparer.OrdinalIgnoreCase);
 		}
-
-		/// <summary>
-		/// Evite de devoir mettre des .ToString() partout
-		/// </summary>
-		/// <param name="dic"></param>
-		/// <param name="enumKey"></param>
-		/// <returns></returns>
-		public static bool ContainsKey<T>(this Dictionary<string, T> dic, Enum enumKey)
-		{
-			return dic.ContainsKey(enumKey.ToString());
-		}
-
+        
 		/// <summary>
 		/// Permet d'ajouter une clé de type Enum sans devoir mettre un .ToString()
 		/// </summary>

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -8,27 +8,7 @@ namespace NExtends.Primitives
 {
 	public static class GenericExtensions
 	{
-		/// <summary>
-		/// Ajout d'une méthode pour supprimer le premier élément d'une List
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="list"></param>
-		/// <returns></returns>
-		public static T Shift<T>(this List<T> list)
-		{
-			if (list.Count > 0)
-			{
-				var first = list[0];
-				list.RemoveAt(0);
-
-				return first;
-			}
-			else
-			{
-				return default(T);
-			}
-		}
-
+		
 		/// <summary>
 		/// Pour reconstruire un Dictionnaire après avoir faire un .Where dessus
 		/// </summary>

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -9,16 +9,12 @@ namespace NExtends.Primitives
 	public static class GenericExtensions
 	{
 		
-		/// <summary>
-		/// Pour reconstruire un Dictionnaire après avoir faire un .Where dessus
-		/// </summary>
-		/// <typeparam name="T1"></typeparam>
-		/// <typeparam name="T2"></typeparam>
-		/// <param name="ienum"></param>
-		/// <returns></returns>
-		public static Dictionary<T1, T2> ToDictionary<T1, T2>(this IEnumerable<KeyValuePair<T1, T2>> ienum)
+        /// <summary>
+        /// Build a Dictionary 
+        /// </summary>
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
 		{
-			return new Dictionary<T1, T2>(ienum);
+			return new Dictionary<TKey, TValue>(source);
 		}
 
 		/// <summary>

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -180,12 +180,12 @@ namespace NExtends.Primitives
 				yield return resultObject;
 			}
 		}
-		public static HashSet<T> ToHashSet<T>(this IEnumerable<T> collection)
-		{
-			return new HashSet<T>(collection);
-		}
+
+#if NET461
+		public static HashSet<TSource> ToHashSet<TSource>(this IEnumerable<TSource> collection) => new HashSet<TSource>(collection);
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsNullOrEmpty<T>(this IEnumerable<T> source) => source == null || !source.Any();
+        public static bool IsNullOrEmpty<TSource>(this IEnumerable<TSource> source) => source == null || !source.Any();
     }
 }

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -38,7 +38,7 @@ namespace NExtends.Primitives
 		/// <returns></returns>
 		public static Dictionary<T1, T2> ToDictionary<T1, T2>(this IEnumerable<KeyValuePair<T1, T2>> ienum)
 		{
-			return ienum.ToDictionary(K => K.Key, K => K.Value);
+			return new Dictionary<T1, T2>(ienum);
 		}
 
 		/// <summary>

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -118,9 +118,11 @@ namespace NExtends.Primitives
 			}
 		}
 
-		public static Dictionary<T, U> Concat<T, U>(this Dictionary<T, U> first, Dictionary<T, U> second)
-		{
-			return first.ToList().Concat(second.ToList()).ToDictionary(k => k.Key, k => k.Value);
+		public static Dictionary<TKey, TValue> Concat<TKey, TValue>(this Dictionary<TKey, TValue> first, Dictionary<TKey, TValue> second)
+        {
+            IEnumerable<KeyValuePair<TKey, TValue>> firstDictionary = first;
+            IEnumerable<KeyValuePair<TKey, TValue>> secondDictionary = second;
+            return firstDictionary.Concat(secondDictionary).ToDictionary(k => k.Key, k => k.Value);
 		}
 
 		/// <summary>

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -13,7 +13,8 @@ namespace NExtends.Primitives
         /// Build a Dictionary 
         /// </summary>
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
-		{
+        {
+
 #if NETCOREAPP2_0
             return new Dictionary<TKey, TValue>(source);
 #else
@@ -22,34 +23,44 @@ namespace NExtends.Primitives
         }
 
         /// <summary>
-        /// Permet d'avoir les collections liées aux clés étrangères compatible entre le DBML et l'EDMX
+        /// Adds the elements of the specified collection to the end
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="collection"></param>
-        /// <param name="elements"></param>
-        public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> elements)
-		{
-			foreach (var element in elements)
+        public static void AddRange<T>(this ICollection<T> source, IEnumerable<T> elements)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            foreach (T element in elements)
 			{
-				collection.Add(element);
+				source.Add(element);
 			}
-		}
+        }
 
-		/// <summary>
-		/// Pour supprimer plusieurs éléments d'un coup
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="collection"></param>
-		/// <param name="elements"></param>
-		public static void RemoveRange<T>(this ICollection<T> collection, IEnumerable<T> elements)
-		{
-			foreach (var element in elements)
+        /// <summary>
+        /// Remove the elements of the specified collection
+        /// </summary>
+        public static void RemoveRange<T>(this ICollection<T> source, IEnumerable<T> elements)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            foreach (T element in elements)
 			{
-				collection.Remove(element);
+				source.Remove(element);
 			}
-		}
+        }
 
-		public enum SortOrder { Ascending, Descending };
+        /// <summary>
+        /// Adds the elements of the specified collection to the end
+        /// </summary>
+        public static void AddMany<T>(this ICollection<T> list, params T[] objs)
+        {
+            list.AddRange(objs);
+        }
+
+        public enum SortOrder { Ascending, Descending };
 
 		public static IOrderedEnumerable<T> OrderByEnum<T>(this IQueryable<T> query, Func<T, object> orderDelegate, SortOrder sortOrder)
 		{
@@ -63,16 +74,7 @@ namespace NExtends.Primitives
 			}
 		}
 
-		/// <summary>
-		/// Pour pouvoir ajouter plusieurs éléments d'un coup à une List (ex : a, b, c ...)
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="list"></param>
-		/// <param name="objs"></param>
-		public static void AddMany<T>(this ICollection<T> list, params T[] objs)
-		{
-			list.AddRange(objs);
-		}
+
 
 		/// <summary>
 		/// Permet d'envoyer l'élément ET son indice dans un ForEach

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -14,16 +14,20 @@ namespace NExtends.Primitives
         /// </summary>
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
 		{
-			return new Dictionary<TKey, TValue>(source);
-		}
+#if NETCOREAPP2_0
+            return new Dictionary<TKey, TValue>(source);
+#else
+            return source.ToDictionary(item => item.Key, item => item.Value);
+#endif
+        }
 
-		/// <summary>
-		/// Permet d'avoir les collections liées aux clés étrangères compatible entre le DBML et l'EDMX
-		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="collection"></param>
-		/// <param name="elements"></param>
-		public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> elements)
+        /// <summary>
+        /// Permet d'avoir les collections liées aux clés étrangères compatible entre le DBML et l'EDMX
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="collection"></param>
+        /// <param name="elements"></param>
+        public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> elements)
 		{
 			foreach (var element in elements)
 			{
@@ -97,16 +101,20 @@ namespace NExtends.Primitives
 		/// <summary>
 		/// Swap specifi key
 		/// </summary>
-		public static void UpdateKey<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey oldKey, TKey newKey)
+		public static void UpdateKey<TKey, TValue>(this IDictionary<TKey, TValue> source, TKey oldKey, TKey newKey)
 		{
-            if (dict.TryGetValue(newKey, out TValue value))
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+            if (source.TryGetValue(newKey, out TValue value))
 			{
 				throw new ArgumentException("The new key is already present in the dictionary");
 			}
-			if (dict.TryGetValue(oldKey, out value))
+			if (source.TryGetValue(oldKey, out value))
 			{
-				dict.Remove(oldKey);
-				dict.Add(newKey, value);
+				source.Remove(oldKey);
+				source.Add(newKey, value);
 			}
 			else
 			{

--- a/NExtends/Primitives/Generics.extensions.cs
+++ b/NExtends/Primitives/Generics.extensions.cs
@@ -99,18 +99,13 @@ namespace NExtends.Primitives
 		}
         
 		/// <summary>
-		/// Permet de renommer une clé
+		/// Swap specifi key
 		/// </summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="dict"></param>
-		/// <param name="oldKey"></param>
-		/// <param name="newKey"></param>
-		public static void UpdateKey<T>(this Dictionary<string, T> dict, string oldKey, string newKey)
+		public static void UpdateKey<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey oldKey, TKey newKey)
 		{
-			T value;
-			if (dict.TryGetValue(newKey, out value))
+            if (dict.TryGetValue(newKey, out TValue value))
 			{
-				throw new Exception("The new key is already present in the dictionary");
+				throw new ArgumentException("The new key is already present in the dictionary");
 			}
 			if (dict.TryGetValue(oldKey, out value))
 			{
@@ -119,7 +114,7 @@ namespace NExtends.Primitives
 			}
 			else
 			{
-				throw new Exception("The key '" + oldKey + "' does not exist in the dictionary");
+				throw new KeyNotFoundException("The key '" + oldKey + "' does not exist in the dictionary");
 			}
 		}
 


### PR DESCRIPTION
Adds coverage for most methods in generic extension methods.
- Remove Shift (only used in legacy YupieManager.cs)
- Remove Add and ContainsKey methods : dangerous method given the unusual use case
- Refactoring of UpdateKey, Contains methods
- Specific targeting for ToDictionary & ToHashSet (api surface differs between net461 & netcoreapp2)
