### PR TITLE
ADD : TimeService

### DIFF
--- a/NExtends.Tests/Time/StandardTimeServiceTests.cs
+++ b/NExtends.Tests/Time/StandardTimeServiceTests.cs
@@ -1,0 +1,34 @@
+﻿using NExtends.Time;
+using System;
+using Xunit;
+
+namespace NExtends.Tests.Time
+{
+    public class StandardTimeServiceTests
+    {
+        [Fact]
+        public void StandardTime_should_beCloseToDateTimeDotNow()
+        {
+            var standardTimeService = new StandardTimeService();
+
+            var now = DateTime.Now;
+            var almostNow = standardTimeService.Now;
+
+            var difference = (almostNow - now).TotalSeconds;
+
+            Assert.InRange<double>(difference, 0, 1);
+        }
+
+        [Fact]
+        public void StandardTime_should_beCloseToDateTimeDotToday()
+        {
+            var standardTimeService = new StandardTimeService();
+
+            var today = DateTime.Today;
+            var almostToday = standardTimeService.Today;
+
+            //This test can fail if run at midnight !
+            Assert.Equal(today, almostToday);
+        }
+    }
+}

--- a/NExtends.Tests/Time/WaybackTimeServiceTests.cs
+++ b/NExtends.Tests/Time/WaybackTimeServiceTests.cs
@@ -1,0 +1,36 @@
+﻿using NExtends.Time;
+using System;
+using System.Threading;
+using Xunit;
+
+namespace NExtends.Tests.Time
+{
+    public class WaybackTimeServiceTests
+    {
+        [Fact]
+        public void WaybackTime_should_beCloseToASpecifiedTime()
+        {
+            var reference = new DateTime(2018, 01, 01, 14, 00, 00);
+            var waybackTimeService = new WaybackTimeService(reference);
+
+            Thread.Sleep(100); //100 milliseconds
+
+            var almostThen = waybackTimeService.Now;
+
+            var difference = (almostThen - reference).TotalMilliseconds;
+
+            Assert.InRange<double>(difference, 100, 200);
+        }
+
+        [Fact]
+        public void WaybackTime_should_beCloseToASpecifiedDate()
+        {
+            var reference = new DateTime(2018, 01, 01, 14, 00, 00);
+            var waybackTimeService = new WaybackTimeService(reference);
+
+            var thatDay = waybackTimeService.Today;
+
+            Assert.Equal(reference.Date, thatDay);
+        }
+    }
+}

--- a/NExtends/Time/ITimeService.cs
+++ b/NExtends/Time/ITimeService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NExtends.Time
+{
+    public interface ITimeService
+    {
+        DateTime Today { get; }
+        DateTime Now { get; }
+    }
+}

--- a/NExtends/Time/StandardTimeService.cs
+++ b/NExtends/Time/StandardTimeService.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace NExtends.Time
+{
+    public class StandardTimeService : ITimeService
+    {
+        public DateTime Today => DateTime.Today;
+        public DateTime Now => DateTime.Now;
+    }
+}

--- a/NExtends/Time/WaybackTimeService.cs
+++ b/NExtends/Time/WaybackTimeService.cs
@@ -4,8 +4,8 @@ namespace NExtends.Time
 {
     public class WaybackTimeService : ITimeService
     {
-        private DateTime _reference;
-        private DateTime _instantiatedAt;
+        private readonly DateTime _reference;
+        private readonly DateTime _instantiatedAt;
 
         public WaybackTimeService(DateTime reference)
         {

--- a/NExtends/Time/WaybackTimeService.cs
+++ b/NExtends/Time/WaybackTimeService.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace NExtends.Time
+{
+    public class WaybackTimeService : ITimeService
+    {
+        private DateTime _reference;
+        private DateTime _instantiatedAt;
+
+        public WaybackTimeService(DateTime reference)
+        {
+            _reference = reference;
+            _instantiatedAt = DateTime.Now;
+        }
+
+        public DateTime Today => Now.Date;
+        public DateTime Now => _reference.AddTicks((DateTime.Now - _instantiatedAt).Ticks);
+    }
+}


### PR DESCRIPTION
Permet de mocker DateTime.Now dans les tests, il suffit d'injecter un ITimeService là où on a besoin de DateTime.Now ou .Today dans le code, et ainsi avoir des tests qui sont agnostics du temps qui passe