### PR TITLE
Json n update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-﻿*/bin/*
-*/obj/*
-
-*.suo
+﻿*.suo
 *.dll
 *.pdb
 *.cache
@@ -19,3 +16,6 @@ packages/# NuGet Packages
 /ComputeVersion.ps1
 /.versionCounter
 /NExtends/*.user
+
+*/bin
+*/obj

--- a/NExtends.Tests/Json/JsonTests.cs
+++ b/NExtends.Tests/Json/JsonTests.cs
@@ -1,0 +1,130 @@
+﻿using Newtonsoft.Json.Linq;
+using NExtends.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace NExtends.Tests.Json
+{
+    public class JsonTests
+    {
+        [Fact]
+        public void JsonValueTests()
+        {
+            var value = new JsonValue("poney");
+
+            Assert.True(value.HasKey((string)null));
+            Assert.True(value.HasKey(""));
+            Assert.True(value.HasKey((Queue<string>)null));
+
+            Assert.True(value.HasJsonValue(""));
+            Assert.False(value.HasJsonArray(""));
+            Assert.False(value.HasJsonObject(""));
+            Assert.False(value.HasJsonValue("sss"));
+
+            Assert.Equal("poney", value.GetJsonValue(""));
+            Assert.Throws<ArgumentException>(() => value.GetJsonArray(""));
+            Assert.Throws<ArgumentException>(() => value.GetJsonObject(""));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue("sss"));
+        }
+
+        [Fact]
+        public void JsonObjectTests()
+        {
+            var value = new JsonObject(new Dictionary<string, string> { { "aaa", "bbb" } });
+
+            Assert.True(value.HasKey((string)null));
+            Assert.True(value.HasKey(""));
+            Assert.True(value.HasKey((Queue<string>)null));
+            Assert.False(value.HasKey("nope"));
+
+            Assert.False(value.HasJsonValue(""));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue(""));
+            Assert.True(value.HasJsonValue("aaa"));
+            Assert.Equal("bbb", value.GetJsonValue("aaa"));
+            Assert.False(value.HasJsonValue("nope"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue("nope"));
+
+            Assert.False(value.HasJsonArray(""));
+            Assert.Throws<ArgumentException>(() => value.GetJsonArray(""));
+            Assert.False(value.HasJsonArray("nope"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonArray("nope"));
+
+            Assert.True(value.HasJsonObject(""));
+            Assert.Equal(value, value.GetJsonObject(""));
+            Assert.False(value.HasJsonObject("nope"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonObject("nope"));
+        }
+
+        [Fact]
+        public void JsonArrayTests()
+        {
+            var jobj = new JsonObject("aaa", new JsonValue("bbb"));
+            var value = new JsonArray(new[] { jobj });
+
+            Assert.True(value.HasKey((string)null));
+            Assert.True(value.HasKey(""));
+            Assert.True(value.HasKey((Queue<string>)null));
+            Assert.True(value.HasKey("0"));
+            Assert.False(value.HasKey("nope"));
+
+            Assert.False(value.HasJsonValue(""));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue(""));
+            Assert.False(value.HasJsonValue("nope"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue("nope"));
+            Assert.False(value.HasJsonValue("-23"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue("-23"));
+            Assert.False(value.HasJsonValue("23"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue("23"));
+            Assert.False(value.HasJsonValue("0"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue("0"));
+
+            Assert.True(value.HasJsonArray(""));
+            Assert.Equal(value, value.GetJsonArray(""));
+            Assert.False(value.HasJsonArray("nope"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonArray("nope"));
+            Assert.False(value.HasJsonArray("-23"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonArray("-23"));
+            Assert.False(value.HasJsonArray("23"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonArray("23"));
+            Assert.False(value.HasJsonArray("0"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonArray("0"));
+
+            Assert.False(value.HasJsonObject(""));
+            Assert.Throws<ArgumentException>(() => value.GetJsonObject(""));
+            Assert.False(value.HasJsonObject("nope"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonObject("nope"));
+            Assert.False(value.HasJsonObject("-23"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonObject("-23"));
+            Assert.False(value.HasJsonObject("23"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonObject("23"));
+            Assert.True(value.HasJsonObject("0"));
+            Assert.Equal(jobj, value.GetJsonObject("0"));
+            Assert.Throws<ArgumentException>(() => value.GetJsonValue("0"));
+        }
+
+        [Fact]
+        public void Json()
+        {
+            var anonymous = new { Date = DateTime.Today };
+            var json = new JsonParser().ParseFromAnonymous(anonymous);
+            Assert.Equal(DateTime.Today.ToString("o"), json.GetJsonValue("Date"));
+
+            Assert.Null(new JsonParser().Parse((JToken)null));
+            var input = @"[{""key"": 1}, {""key"": 2}]";
+            json = new JsonParser().Parse(input);
+
+            Assert.Equal(new HashSet<string> { "0.key", "1.key" }, json.GetPaths());
+
+            var array = json.GetJsonArray("");
+            Assert.Equal(2, (json.GetContent() as Array).Length);
+            Assert.Equal(new List<string> { "1", "2" }, array.GetEveryJsonValue("key"));
+
+            var jObject = json.GetJsonObject("0");
+            Assert.Single(jObject.GetContent() as Dictionary<string, object>);
+
+            Assert.Equal("1", json.GetJsonValue("0.key"));
+        }
+    }
+}

--- a/NExtends.Tests/NExtends.Tests.csproj
+++ b/NExtends.Tests/NExtends.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.2;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <ProjectGuid>{9EA0C475-5A2B-4589-8526-520DEAF6111F}</ProjectGuid>
   </PropertyGroup>
 
@@ -14,10 +14,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
 	  <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="Primitives\DateTimes\DateTime.extensions.tests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NExtends.Tests/NExtends.Tests.csproj
+++ b/NExtends.Tests/NExtends.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;net461</TargetFrameworks>
     <ProjectGuid>{9EA0C475-5A2B-4589-8526-520DEAF6111F}</ProjectGuid>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/NExtends.Tests/NExtends.Tests.csproj
+++ b/NExtends.Tests/NExtends.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <ProjectGuid>{9EA0C475-5A2B-4589-8526-520DEAF6111F}</ProjectGuid>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/NExtends.Tests/NExtends.Tests.csproj
+++ b/NExtends.Tests/NExtends.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>    
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <ProjectGuid>{9EA0C475-5A2B-4589-8526-520DEAF6111F}</ProjectGuid>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NExtends/Json/IJsonElement.cs
+++ b/NExtends/Json/IJsonElement.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace NExtends.Json
+{
+    public interface IJsonElement
+    {
+        object GetContent();
+
+        HashSet<string> GetPaths();
+
+        JsonArray GetJsonArray(string path);
+        JsonArray GetJsonArray(Queue<string> path);
+
+        JsonObject GetJsonObject(string path);
+        JsonObject GetJsonObject(Queue<string> path);
+
+        string GetJsonValue(string path);
+        string GetJsonValue(Queue<string> path);
+
+        bool HasJsonArray(string path);
+        bool HasJsonArray(Queue<string> path);
+
+        bool HasJsonObject(string path);
+        bool HasJsonObject(Queue<string> path);
+
+        bool HasJsonValue(string path);
+        bool HasJsonValue(Queue<string> path);
+
+        bool HasKey(string path);
+        bool HasKey(Queue<string> path);
+    }
+}

--- a/NExtends/Json/IJsonParser.cs
+++ b/NExtends/Json/IJsonParser.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace NExtends.Json
+{
+    public interface IJsonParser
+    {
+        IJsonElement Parse(string input);
+        IJsonElement Parse(JToken input);
+        IJsonElement ParseFromAnonymous(object input);
+    }
+}

--- a/NExtends/Json/JsonArray.cs
+++ b/NExtends/Json/JsonArray.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NExtends.Json
+{
+    public class JsonArray : JsonElement
+    {
+        public List<IJsonElement> Content { get; set; }
+
+        public JsonArray() : this(new List<IJsonElement>()) { }
+        public JsonArray(IEnumerable<IJsonElement> elements)
+        {
+            Content = elements.ToList();
+        }
+
+        public override object GetContent()
+        {
+            return Content.Select(e => e == null ? null : e.GetContent()).ToArray();
+        }
+
+        public override HashSet<string> GetPaths()
+        {
+            return new HashSet<string>(Content.SelectMany((e, index) => e.GetPaths().Select(p => index + "." + p)));
+        }
+
+        public List<string> GetEveryJsonValue()
+        {
+            return GetEveryJsonValue(null);
+        }
+
+        public List<string> GetEveryJsonValue(string path)
+        {
+            if (Content == null)
+            {
+                return null;
+            }
+
+            return Content.Select(e => e.GetJsonValue(path)).ToList();
+        }
+
+        public bool HasEveryJsonValue(string path)
+        {
+            if (Content == null || Content.Count == 0)
+            {
+                return false;
+            }
+
+            return Content.All(e => e.HasJsonValue(path));
+        }
+
+        public override JsonArray GetJsonArray(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                return this;
+            }
+
+            var currentPath = path.Dequeue();
+            if (int.TryParse(currentPath, out var index) && 0 <= index && index < Content.Count)
+            {
+                return Content[index].GetJsonArray(path);
+            }
+            throw new ArgumentException("Path on a json array must be a valid integer");
+        }
+
+        public override JsonObject GetJsonObject(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                throw new ArgumentException("The suggested empty json path does not exist on this json array");
+            }
+
+            var currentPath = path.Dequeue();
+            if (int.TryParse(currentPath, out var index) && 0 <= index && index < Content.Count)
+            {
+                return Content[index].GetJsonObject(path);
+            }
+            throw new ArgumentException("Path on a json array must be a valid integer");
+        }
+
+        public override string GetJsonValue(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                throw new ArgumentException("The suggested empty json path does not exist on this json array");
+            }
+
+            var currentPath = path.Dequeue();
+            if (int.TryParse(currentPath, out var index) && 0 <= index && index < Content.Count)
+            {
+                return Content[index].GetJsonValue(path);
+            }
+            throw new ArgumentException("Path on a json array must be a valid integer");
+        }
+
+        public override bool HasJsonArray(Queue<string> path) => path == null || path.Count == 0 ||
+        (
+            int.TryParse(path.Dequeue(), out var index)
+            && 0 <= index && index < Content.Count
+            && Content[index].HasJsonArray(path)
+        );
+
+        public override bool HasJsonObject(Queue<string> path) =>
+            path != null
+            && path.Count != 0
+            && int.TryParse(path.Dequeue(), out var index)
+            && 0 <= index && index < Content.Count
+            && Content[index].HasJsonObject(path);
+
+        public override bool HasJsonValue(Queue<string> path) =>
+            path != null
+            && path.Count != 0
+            && int.TryParse(path.Dequeue(), out var index)
+            && 0 <= index && index < Content.Count
+            && Content[index].HasJsonValue(path);
+
+        public override bool HasKey(Queue<string> path) => path == null || path.Count == 0 ||
+        (
+            int.TryParse(path.Dequeue(), out var index)
+            && 0 <= index && index < Content.Count
+            && Content[index].HasKey(path)
+        );
+    }
+}

--- a/NExtends/Json/JsonElement.cs
+++ b/NExtends/Json/JsonElement.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NExtends.Json
+{
+    public abstract class JsonElement : IJsonElement
+    {
+        public abstract object GetContent();
+
+        public abstract HashSet<string> GetPaths();
+
+        public JsonArray GetJsonArray(string path) => GetJsonArray(ParsePath(path));
+        public abstract JsonArray GetJsonArray(Queue<string> path);
+
+        public JsonObject GetJsonObject(string path) => GetJsonObject(ParsePath(path));
+        public abstract JsonObject GetJsonObject(Queue<string> path);
+
+        public string GetJsonValue(string path) => GetJsonValue(ParsePath(path));
+        public abstract string GetJsonValue(Queue<string> path);
+
+        public bool HasJsonArray(string path) => HasJsonArray(ParsePath(path));
+        public abstract bool HasJsonArray(Queue<string> path);
+
+        public bool HasJsonObject(string path) => HasJsonObject(ParsePath(path));
+        public abstract bool HasJsonObject(Queue<string> path);
+
+        public bool HasJsonValue(string path) => HasJsonValue(ParsePath(path));
+        public abstract bool HasJsonValue(Queue<string> path);
+
+        public bool HasKey(string path) => HasKey(ParsePath(path));
+
+        public abstract bool HasKey(Queue<string> path);
+
+        private Queue<string> ParsePath(string path)
+        {
+            return new Queue<string>((path ?? "").Replace("]", "").Split(new[] { '.', '[' }, StringSplitOptions.RemoveEmptyEntries));
+        }
+    }
+}

--- a/NExtends/Json/JsonObject.cs
+++ b/NExtends/Json/JsonObject.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace NExtends.Json
+{
+    public class JsonObject : JsonElement
+    {
+        public Dictionary<string, IJsonElement> Content { get; set; }
+
+        public JsonObject() : this(new Dictionary<string, IJsonElement>(StringComparer.OrdinalIgnoreCase)) { }
+
+        public JsonObject(string key, IJsonElement element)
+        {
+            Content = new Dictionary<string, IJsonElement>(StringComparer.OrdinalIgnoreCase);
+            Content[key] = element;
+        }
+
+        public JsonObject(Dictionary<string, string> data) : this(data.ToDictionary(kvp => kvp.Key, kvp => (IJsonElement)new JsonValue { Content = kvp.Value }, StringComparer.OrdinalIgnoreCase)) { }
+        public JsonObject(Dictionary<string, IJsonElement> content)
+        {
+            Content = content;
+        }
+
+        public bool IsEmpty()
+        {
+            return Content.Count == 0;
+        }
+
+        public override object GetContent()
+        {
+            return Content.ToDictionary(p => p.Key, p => p.Value?.GetContent());
+        }
+
+        public override HashSet<string> GetPaths()
+        {
+            return new HashSet<string>(Content.SelectMany(kvp => kvp.Value.GetPaths().Select(p => kvp.Key + (!string.IsNullOrEmpty(p) ? "." + p : ""))));
+        }
+
+        public override JsonArray GetJsonArray(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                throw new ArgumentException("The suggested empty json path does not exist on this json object");
+            }
+
+            var currentPath = path.Dequeue();
+            if (!Content.ContainsKey(currentPath))
+            {
+                throw new ArgumentException($"The json path '{currentPath}' does not exist on this json object");
+            }
+
+            return Content[currentPath].GetJsonArray(path);
+        }
+
+        public override JsonObject GetJsonObject(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                return this;
+            }
+
+            var currentPath = path.Dequeue();
+            if (!Content.ContainsKey(currentPath))
+            {
+                throw new ArgumentException($"The json path '{currentPath}' does not exist on this json object");
+            }
+
+            return Content[currentPath].GetJsonObject(path);
+        }
+
+        public override string GetJsonValue(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                throw new ArgumentException("The suggested empty json path does not exist on this json object");
+            }
+
+            var currentPath = path.Dequeue();
+            if (!Content.ContainsKey(currentPath))
+            {
+                throw new ArgumentException($"The json path '{currentPath}' does not exist on this json object");
+            }
+
+            return Content[currentPath].GetJsonValue(path);
+        }
+
+        public override bool HasJsonArray(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                return false;
+            }
+
+            var currentPath = path.Dequeue();
+            return Content.ContainsKey(currentPath) && Content[currentPath].HasJsonArray(path);
+        }
+
+        public override bool HasJsonObject(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                return true;
+            }
+
+            var currentPath = path.Dequeue();
+            return Content.ContainsKey(currentPath) && Content[currentPath].HasJsonObject(path);
+        }
+
+        public override bool HasJsonValue(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                return false;
+            }
+
+            var currentPath = path.Dequeue();
+            return Content.ContainsKey(currentPath) && Content[currentPath].HasJsonValue(path);
+        }
+
+        public override bool HasKey(Queue<string> path)
+        {
+            if (path == null || path.Count == 0)
+            {
+                return true;
+            }
+
+            var currentPath = path.Dequeue();
+            return Content.ContainsKey(currentPath) && Content[currentPath].HasKey(path);
+        }
+    }
+}

--- a/NExtends/Json/JsonParser.cs
+++ b/NExtends/Json/JsonParser.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace NExtends.Json
+{
+    public class JsonParser : IJsonParser
+    {
+        public IJsonElement ParseFromAnonymous(object input)
+            => Parse(JObject.FromObject(input));
+
+        public IJsonElement Parse(string input)
+            => Parse((JToken)JsonConvert.DeserializeObject(input));
+
+        public IJsonElement Parse(JToken input)
+        {
+            if (input == null)
+            {
+                return null;
+            }
+
+            switch (input.Type)
+            {
+                case JTokenType.Array:
+                    return ParseArray((JArray)input);
+                //case JTokenType.Comment: 
+                case JTokenType.Uri:
+                case JTokenType.Undefined:
+                case JTokenType.TimeSpan:
+                case JTokenType.String:
+                case JTokenType.Raw:
+                case JTokenType.Property:
+                case JTokenType.Null:
+                case JTokenType.None:
+                case JTokenType.Integer:
+                case JTokenType.Guid:
+                case JTokenType.Float:
+                case JTokenType.Boolean:
+                case JTokenType.Bytes:
+                    return ParseValue(input);
+                case JTokenType.Date:
+                    return ParseDate((DateTime)input);
+                case JTokenType.Object:
+                    return ParseObject((JObject)input);
+            }
+
+            return null;
+        }
+
+        protected JsonArray ParseArray(JArray array)
+        {
+            var result = new JsonArray();
+            foreach (var token in array)
+            {
+                result.Content.Add(Parse(token));
+            }
+            return result;
+        }
+
+        protected IJsonElement ParseObject(JObject obj)
+        {
+            var result = new JsonObject();
+            foreach (var kvp in obj)
+            {
+                result.Content.Add(kvp.Key, Parse(kvp.Value));
+            }
+            return result;
+        }
+
+        protected IJsonElement ParseValue(JToken value) => new JsonValue { Content = value.Value<string>() };
+
+        protected IJsonElement ParseDate(DateTime date) => new JsonValue { Content = date.ToString("o") };
+    }
+}

--- a/NExtends/Json/JsonValue.cs
+++ b/NExtends/Json/JsonValue.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NExtends.Json
+{
+    public class JsonValue : JsonElement
+    {
+        public object Content { get; set; }
+
+        public JsonValue() { }
+        public JsonValue(object value)
+        {
+            Content = value;
+        }
+
+        public override object GetContent() => Content;
+
+        public override HashSet<string> GetPaths() => new HashSet<string> { "" };
+
+        public override JsonArray GetJsonArray(Queue<string> path)
+        {
+            throw new ArgumentException($"The json path '{string.Join(".", path)}' does not exist on this json value");
+        }
+
+        public override JsonObject GetJsonObject(Queue<string> path)
+        {
+            throw new ArgumentException($"The json path '{string.Join(".", path)}' does not exist on this json value");
+        }
+
+        public override string GetJsonValue(Queue<string> path)
+        {
+            if (HasJsonValue(path))
+            {
+                return Content?.ToString();
+            }
+
+            throw new ArgumentException($"The json path '{string.Join(".", path)}' does not exist on this json value");
+        }
+
+        public override bool HasJsonArray(Queue<string> path) => false;
+        public override bool HasJsonObject(Queue<string> path) => false;
+        public override bool HasJsonValue(Queue<string> path) => path == null || path.Count == 0;
+
+        public override bool HasKey(Queue<string> path) => HasJsonValue(path);
+    }
+}

--- a/NExtends/NExtends.csproj
+++ b/NExtends/NExtends.csproj
@@ -6,12 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Expressions\" />
   </ItemGroup>
 
 </Project>

--- a/NExtends/Primitives/Strings/String.extensions.cs
+++ b/NExtends/Primitives/Strings/String.extensions.cs
@@ -228,18 +228,22 @@ namespace NExtends.Primitives.Strings
         }
 
         /// <summary>
-        /// Equivalent à Convert.ChangeType mais gère mieux les Enum et les TimeSpan
+        /// Equivalent à Convert.ChangeType mais gère mieux les Enum et les TimeSpan, les dates
         /// </summary>
         /// <param name="value"></param>
         /// <param name="propertyType"></param>
         /// <returns></returns>
         public static object ChangeType(this string value, Type propertyType, IFormatProvider culture)
         {
-            if (propertyType.GetTypeInfo().IsEnum)
+            if (propertyType == typeof(string))
+            {
+                return value;
+            }
+            else if (propertyType.IsEnum)
             {
                 return Enum.Parse(propertyType, value, true);
             }
-            else if (propertyType.Name.Equals("TimeSpan"))
+            else if (propertyType == typeof(TimeSpan))
             {
                 return TimeSpan.Parse(value, culture);
             }
@@ -257,6 +261,18 @@ namespace NExtends.Primitives.Strings
             }
             else
             {
+                if (propertyType == typeof(DateTime) || propertyType == typeof(DateTime?))
+                {
+                    switch (value)
+                    {
+                        case "today": return DateTime.Today;
+                        case "now": return DateTime.Now;
+                        case "tomorrow": return DateTime.Today.AddDays(1);
+                        case "yesterday": return DateTime.Today.AddDays(-1);
+                        default:
+                            break;
+                    }
+                }
                 return Convert.ChangeType(value, propertyType, culture);
             }
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ build_script:
 - ps: dotnet build NExtends.sln -c Debug -v minimal 
 
 test_script:
-- OpenCover.4.7.922\tools\OpenCover.Console.exe -returntargetcode -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test -f netcoreapp2.0 /p:DebugType=full -c Debug .\NExtends.Tests\NExtends.Tests.csproj" -filter:"+[NExtends*]* -[NExtends.Tests*]*" -excludebyattribute:"*.ExcludeFromCodeCoverage*" -output:coverage-opencover.xml
+- OpenCover.4.7.922\tools\OpenCover.Console.exe -returntargetcode -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test -f netcoreapp2.1 /p:DebugType=full -c Debug .\NExtends.Tests\NExtends.Tests.csproj" -filter:"+[NExtends*]* -[NExtends.Tests*]*" -excludebyattribute:"*.ExcludeFromCodeCoverage*" -output:coverage-opencover.xml
 - OpenCover.4.7.922\tools\OpenCover.Console.exe -returntargetcode -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test -f net461 /p:DebugType=full -c Debug .\NExtends.Tests\NExtends.Tests.csproj" -filter:"+[NExtends*]* -[NExtends.Tests*]*" -excludebyattribute:"*.ExcludeFromCodeCoverage*" -mergeoutput -output:coverage-opencover.xml
 - dotnet sonarscanner end /d:"sonar.login=%SONAR_TOKEN%"
 - Codecov.1.0.5\tools\codecov -f coverage-opencover.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,9 +41,9 @@ before_build:
 - dotnet restore
 - cmd: >-
     IF "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (
-    dotnet sonarscanner begin /k:"NExtends" /d:"sonar.analysis.mode=publish" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:sonar.cs.opencover.reportsPaths="coverage-opencover.xml"
+    dotnet sonarscanner begin /k:"NExtends" /d:"sonar.analysis.mode=publish" /d:"sonar.host.url=https://sonarcloud.io" /o:"luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:sonar.cs.opencover.reportsPaths="coverage-opencover.xml"
     ) ELSE (
-    dotnet sonarscanner begin /k:"NExtends" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:"sonar.github.oauth=%GITHUB_ACCESS_TOKEN%" /d:"sonar.pullrequest.provider=github" /d:"sonar.pullrequest.branch=%APPVEYOR_REPO_BRANCH%" /d:"sonar.pullrequest.key=%APPVEYOR_PULL_REQUEST_NUMBER%" /d:"sonar.pullrequest.github.repository=LuccaSA/NExtends" /d:"sonar.pullrequest.github.endpoint=https://api.github.com"
+    dotnet sonarscanner begin /k:"NExtends" /d:"sonar.host.url=https://sonarcloud.io" /o:"luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:"sonar.github.oauth=%GITHUB_ACCESS_TOKEN%" /d:"sonar.pullrequest.provider=github" /d:"sonar.pullrequest.branch=%APPVEYOR_REPO_BRANCH%" /d:"sonar.pullrequest.key=%APPVEYOR_PULL_REQUEST_NUMBER%" /d:"sonar.pullrequest.github.repository=LuccaSA/NExtends" /d:"sonar.pullrequest.github.endpoint=https://api.github.com"
     )
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   - ps: $version = Compute "NExtends\NExtends.csproj" $env:APPVEYOR_BUILD_NUMBER $env:APPVEYOR_REPO_TAG $env:APPVEYOR_PULL_REQUEST_NUMBER
   - ps: Update-AppveyorBuild -Version $version.Semver
   - dotnet tool install --global dotnet-sonarscanner
-  - nuget install OpenCover -Version 4.6.519 
+  - nuget install OpenCover -Version 4.7.922 
   - nuget install Codecov -Version 1.0.5 
 
 before_build:
@@ -50,8 +50,8 @@ build_script:
 - ps: dotnet build NExtends.sln -c Debug -v minimal 
 
 test_script:
-- OpenCover.4.6.519\tools\OpenCover.Console.exe -returntargetcode -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test -f netcoreapp2.0 /p:DebugType=full -c Debug .\NExtends.Tests\NExtends.Tests.csproj" -filter:"+[NExtends*]* -[NExtends.Tests*]*" -excludebyattribute:"*.ExcludeFromCodeCoverage*" -output:coverage-opencover.xml
-- OpenCover.4.6.519\tools\OpenCover.Console.exe -returntargetcode -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test -f net461 /p:DebugType=full -c Debug .\NExtends.Tests\NExtends.Tests.csproj" -filter:"+[NExtends*]* -[NExtends.Tests*]*" -excludebyattribute:"*.ExcludeFromCodeCoverage*" -mergeoutput -output:coverage-opencover.xml
+- OpenCover.4.7.922\tools\OpenCover.Console.exe -returntargetcode -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test -f netcoreapp2.0 /p:DebugType=full -c Debug .\NExtends.Tests\NExtends.Tests.csproj" -filter:"+[NExtends*]* -[NExtends.Tests*]*" -excludebyattribute:"*.ExcludeFromCodeCoverage*" -output:coverage-opencover.xml
+- OpenCover.4.7.922\tools\OpenCover.Console.exe -returntargetcode -oldstyle -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test -f net461 /p:DebugType=full -c Debug .\NExtends.Tests\NExtends.Tests.csproj" -filter:"+[NExtends*]* -[NExtends.Tests*]*" -excludebyattribute:"*.ExcludeFromCodeCoverage*" -mergeoutput -output:coverage-opencover.xml
 - dotnet sonarscanner end /d:"sonar.login=%SONAR_TOKEN%"
 - Codecov.1.0.5\tools\codecov -f coverage-opencover.xml
 


### PR DESCRIPTION
Ces classes json existent aujourd'hui dans le monolithe et dans rdd v3.
Avec l'extraction future de tproj, j'aurais besoin de créer de nouvelles librairies qui dépendront de ces classes, donc je m'y prend en avance de phase sur ce sujet.

Mon intention est donc de :
 1 mettre ces classes ici. C'est je pense leur place naturelle, car lucca.core.shared est privé, donc inaccessible à rdd, qui est public.
 2 utilsier ces classes si besoin dans les futurs lucca.core.xxx qui en dépendent
 3 à long terme, virer les classes de Rdd (v4 pour le coup :p) et monolithe

